### PR TITLE
Modify parameters for collector run

### DIFF
--- a/collector/run.sh
+++ b/collector/run.sh
@@ -3,7 +3,7 @@ scala \
     -classpath /tdist-zipkin.jar com.knewton.tdist.zipkin.receiver.kafka.KafkaReceiverApp\
     -zipkin.itemQueue.maxSize=10\
     -com.twitter.finagle.tracing.debugTrace=true\
-    -zipkin.kafka.groupid=0\
-    -zipkin.zookeeper.location=host1:2181,host2:2181,host3:2181/Kafka08\
-    -zipkin.kafka.server=host1:9160,host2:9160,host3:9160\
-    -zipkin.kafka.topics=zipkin-tdist=1
+    -zipkin.kafka.groupid=collector\
+    -zipkin.kafka.server=host1:2181,host2:2181,host3:2181/Kafka08\
+    -zipkin.kafka.topics=zipkin=1\
+    -admin.port=":9903"


### PR DESCRIPTION
We do not need the zookeeper hosts, but we do need the kafka
hosts and they should actually be the zookeeper hosts.

Also named topic simply 'zipkin'.  This topic must be created
in Kafka08 manually, it will not be auto-created.
